### PR TITLE
Remove dependencies upper version bind

### DIFF
--- a/lowgl.cabal
+++ b/lowgl.cabal
@@ -75,11 +75,11 @@ library
   -- other-extensions:    
   
   -- Other library packages from which modules are imported.
-  build-depends:       base >=4.7 && <4.8, 
-                       transformers >= 0.4 && < 0.5,
-                       vector >=0.10 && <0.11, 
-                       linear >= 1.16 && <1.17, 
-                       gl >=0.5 && <0.8, 
+  build-depends:       base >=4.7,
+                       transformers >= 0.4,
+                       vector >=0.10,
+                       linear >= 1.16,
+                       gl >=0.5,
                        data-default
   
   -- Directories containing source files.


### PR DESCRIPTION
lowgl right now seems a bit behind major version (`base` in particular), and seems to build flawlessly with all dependencies at their latest version. Thus, I suggest removing the upper bind on all dependency versions.
